### PR TITLE
Updating coding-standards

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -465,30 +465,32 @@ static size_t x_get_border_rectangles(Con *con, xcb_rectangle_t rectangles[4]) {
  */
 void x_shape_window(Con *con) {
 
-  const xcb_query_extension_reply_t *shape_query;
-  shape_query = xcb_get_extension_data(conn, &xcb_shape_id);
-  if (!shape_query->present) return; 
-  
-  if (con->fullscreen_mode) {
+    const xcb_query_extension_reply_t *shape_query;
+    shape_query = xcb_get_extension_data(conn, &xcb_shape_id);
 
-    xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_BOUNDING, con->frame.id, 0, 0, XCB_NONE);
-    xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_CLIP, con->frame.id, 0, 0, XCB_NONE);
+    if (!shape_query->present) {
+        return;
+    }
 
-  } else {
+    if (con->fullscreen_mode) {
+        xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_BOUNDING, con->frame.id, 0, 0, XCB_NONE);
+        xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_CLIP, con->frame.id, 0, 0, XCB_NONE);
+        return;
+    }
 
     uint16_t w  = con->rect.width;
     uint16_t h  = con->rect.height;
-    
+
     xcb_pixmap_t pid = xcb_generate_id(conn);
-    
+
     xcb_create_pixmap(conn, 1, pid, con->frame.id, w, h);
-    
+
     xcb_gcontext_t black = xcb_generate_id(conn);
     xcb_gcontext_t white = xcb_generate_id(conn);
-    
+
     xcb_create_gc(conn, black, pid, XCB_GC_FOREGROUND, (uint32_t[]){0, 0});
     xcb_create_gc(conn, white, pid, XCB_GC_FOREGROUND, (uint32_t[]){1, 0});
-    
+
     int32_t r = 13;
     int32_t d = r * 2;
 
@@ -498,47 +500,42 @@ void x_shape_window(Con *con) {
         con->parent->layout == L_TABBED ||
         con->parent->layout == L_STACKED) {
 
-      xcb_arc_t arcs[] = {
-                          { -1, h-d, d, d, 0, 360 << 6 },
-                          { w-d, h-d, d, d, 0, 360 << 6 }
-      };
-      
-      xcb_rectangle_t rects[] = {
-                                 { r, 0, w-d, h },
-                                 { 0, 0, w, h-r },
-      };
-      
-      xcb_poly_fill_rectangle(conn, pid, black, 1, &bounding);
-      xcb_poly_fill_rectangle(conn, pid, white, 2, rects);
-      xcb_poly_fill_arc(conn, pid, white, 2, arcs);
+        xcb_arc_t arcs[] = {
+            { -1, h-d, d, d, 0, 360 << 6 },
+            { w-d, h-d, d, d, 0, 360 << 6 }
+        };
+
+        xcb_rectangle_t rects[] = {
+            { r, 0, w-d, h },
+            { 0, 0, w, h-r },
+        };
+
+        xcb_poly_fill_rectangle(conn, pid, black, 1, &bounding);
+        xcb_poly_fill_rectangle(conn, pid, white, 2, rects);
+        xcb_poly_fill_arc(conn, pid, white, 2, arcs);
 
     } else {
 
-      xcb_arc_t arcs[] = {
-                          { -1, -1, d, d, 0, 360 << 6 },
-                          { -1, h-d, d, d, 0, 360 << 6 },
-                          { w-d, -1, d, d, 0, 360 << 6 },
-                          { w-d, h-d, d, d, 0, 360 << 6 },
-      };
-      
-      xcb_rectangle_t rects[] = {
-                                 { r, 0, w-d, h },
-                                 { 0, r, w, h-d },
-      };
-      
-      xcb_poly_fill_rectangle(conn, pid, black, 1, &bounding);
-      xcb_poly_fill_rectangle(conn, pid, white, 2, rects);
-      xcb_poly_fill_arc(conn, pid, white, 4, arcs);
+        xcb_arc_t arcs[] = {
+            { -1, -1, d, d, 0, 360 << 6 },
+            { -1, h-d, d, d, 0, 360 << 6 },
+            { w-d, -1, d, d, 0, 360 << 6 },
+            { w-d, h-d, d, d, 0, 360 << 6 },
+        };
 
+        xcb_rectangle_t rects[] = {
+            { r, 0, w-d, h },
+            { 0, r, w, h-d },
+        };
+
+        xcb_poly_fill_rectangle(conn, pid, black, 1, &bounding);
+        xcb_poly_fill_rectangle(conn, pid, white, 2, rects);
+        xcb_poly_fill_arc(conn, pid, white, 4, arcs);
     }
-    
+
     xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_BOUNDING, con->frame.id, 0, 0, pid);
     xcb_shape_mask(conn, XCB_SHAPE_SO_SET, XCB_SHAPE_SK_CLIP, con->frame.id, 0, 0, pid);
-    
     xcb_free_pixmap(conn, pid);
-
-  }
-
 }
 
 /*


### PR DESCRIPTION
## Summary

Minor code changes to align new code with original coding standards:
- Four spaces for indentation
- Returning early to avoid excess nesting
- Removing spaces on lines without code