### PR TITLE
Make the corner's radius customizable with border_radius param in .i3/config

### DIFF
--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -45,6 +45,7 @@ CFGFUN(for_window, const char *command);
 CFGFUN(gaps, const char *workspace, const char *type, const long value);
 CFGFUN(smart_borders, const char *enable);
 CFGFUN(smart_gaps, const char *enable);
+CFGFUN(border_radius, const long radius);
 CFGFUN(floating_minimum_size, const long width, const long height);
 CFGFUN(floating_maximum_size, const long width, const long height);
 CFGFUN(default_orientation, const char *orientation);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -263,6 +263,9 @@ struct Config {
 
     /* Disable gaps if there is only one container on the workspace */
     smart_gaps_t smart_gaps;
+
+    /* Border radius (resloved/i3) */
+    int32_t border_radius;
 };
 
 /**

--- a/include/data.h
+++ b/include/data.h
@@ -793,4 +793,6 @@ struct Con {
 
     /* The colormap for this con if a custom one is used. */
     xcb_colormap_t colormap;
+    
+    uint32_t border_radius;
 };

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -27,6 +27,7 @@ state INITIAL:
   'gaps'                                   -> GAPS
   'smart_borders'                          -> SMART_BORDERS
   'smart_gaps'                             -> SMART_GAPS
+  'border_radius'                          -> BORDER_RADIUS
   'floating_minimum_size'                  -> FLOATING_MINIMUM_SIZE_WIDTH
   'floating_maximum_size'                  -> FLOATING_MAXIMUM_SIZE_WIDTH
   'floating_modifier'                      -> FLOATING_MODIFIER
@@ -89,6 +90,11 @@ state SMART_GAPS:
       -> call cfg_smart_gaps($enabled)
   enabled = 'inverse_outer'
       -> call cfg_smart_gaps($enabled)
+
+# border_radius <radius>
+state BORDER_RADIUS:
+  radius = number
+      -> call cfg_border_radius(&radius)
 
 # floating_minimum_size <width> x <height>
 state FLOATING_MINIMUM_SIZE_WIDTH:

--- a/src/con.c
+++ b/src/con.c
@@ -1611,6 +1611,9 @@ Rect con_border_style_rect(Con *con) {
             return (Rect){0, 0, 0, 0};
     }
 
+    // Copy border_radius from config to con 
+    con->border_radius = config.border_radius;
+
     adjacent_t borders_to_hide = ADJ_NONE;
     int border_width = con->current_border_width;
     DLOG("The border width for con is set to: %d\n", con->current_border_width);

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -318,6 +318,10 @@ CFGFUN(smart_gaps, const char *enable) {
         config.smart_gaps = eval_boolstr(enable) ? SMART_GAPS_ON : SMART_GAPS_OFF;
 }
 
+CFGFUN(border_radius, const long radius) {
+    config.border_radius = radius;
+}
+
 CFGFUN(floating_minimum_size, const long width, const long height) {
     config.floating_minimum_width = width;
     config.floating_minimum_height = height;

--- a/src/x.c
+++ b/src/x.c
@@ -479,7 +479,10 @@ void x_shape_title(Con *con){
     xcb_create_gc(conn, black, pid, XCB_GC_FOREGROUND, (uint32_t[]){0, 0});
     xcb_create_gc(conn, white, pid, XCB_GC_FOREGROUND, (uint32_t[]){1, 0});
 
-    int32_t r = 4;
+    int32_t r = con->border_radius;
+    if (r == 0) {
+        r = 4;
+    }
     int32_t d = r * 2;
 
     xcb_rectangle_t bounding = {0, 0, w, h};
@@ -537,7 +540,10 @@ void x_shape_window(Con *con) {
     xcb_create_gc(conn, black, pid, XCB_GC_FOREGROUND, (uint32_t[]){0, 0});
     xcb_create_gc(conn, white, pid, XCB_GC_FOREGROUND, (uint32_t[]){1, 0});
 
-    int32_t r = 4;
+    int32_t r = con->border_radius;
+    if (r == 0) {
+        r = 4;
+    }
     int32_t d = r * 2;
 
     xcb_rectangle_t bounding = {0, 0, w, h};

--- a/src/x.c
+++ b/src/x.c
@@ -480,9 +480,6 @@ void x_shape_title(Con *con){
     xcb_create_gc(conn, white, pid, XCB_GC_FOREGROUND, (uint32_t[]){1, 0});
 
     int32_t r = con->border_radius;
-    if (r == 0) {
-        r = 4;
-    }
     int32_t d = r * 2;
 
     xcb_rectangle_t bounding = {0, 0, w, h};
@@ -541,9 +538,6 @@ void x_shape_window(Con *con) {
     xcb_create_gc(conn, white, pid, XCB_GC_FOREGROUND, (uint32_t[]){1, 0});
 
     int32_t r = con->border_radius;
-    if (r == 0) {
-        r = 4;
-    }
     int32_t d = r * 2;
 
     xcb_rectangle_t bounding = {0, 0, w, h};


### PR DESCRIPTION
Hi @resloved ,

Good job on forking i3 and adding rounded corners. It's brilliant !
I noticed that you hardcoded the radius in the `x.c` file, so I went ahead and made it easier for a user of your fork to change this value. Otherwise, one would need to read the code, change the value, compile and install.  

This PR allows a user to customize the corner's radius by putting the line "border_radius `<number>`" in their i3 config file. Simple ! :)